### PR TITLE
[RFR] Use struct keyword so message variables can be named the same as their type

### DIFF
--- a/bson_bind.cpp
+++ b/bson_bind.cpp
@@ -184,8 +184,14 @@ namespace
   {
     assert(!m.type.empty());
     assert(!m.name.empty());
-    
-    out << "    ";
+    if (m.ext)
+    {
+    	out << "    struct ";
+    }
+    else
+    {
+    	out << "    ";
+    }
     if(!m.required) out << "bson_bind::option<";
     out << (m.vec ? "std::vector<" + m.type + ">" : m.type);
     if(!m.required) out << ">";


### PR DESCRIPTION
This compiles across the board... but I'm still testing.
