### PR TITLE
[RFR] Extra option operator to automatically set some when assigning an optional value

### DIFF
--- a/option.hpp
+++ b/option.hpp
@@ -84,6 +84,15 @@ namespace bson_bind
       return *this;
     }
     
+    template<typename D>
+    option<T> &operator =(const D &rhs)
+    {
+      if(_some) reinterpret_cast<T *>(_t)->~T();
+      _some = true;
+      if(_some) new (_t) T(rhs);
+      return *this;
+    }
+
     option<T> &operator =(const option<T> &rhs)
     {
       if(_some) reinterpret_cast<T *>(_t)->~T();


### PR DESCRIPTION
So you can do something like:

``` c++
battlecreek::set_digital_state set_digital_state;
set_digital_state.port = 0;
set_digital_state.output = true;

set_digital_state_pub->publish(set_digital_state.bind());
```

for battlecreek::set_digital_state defined with `output` as optional: 

``` bson
%package battlecreek
uint8 port!
bool value
bool output
```
